### PR TITLE
Inscrivez-vous: Change to 2nd person

### DIFF
--- a/conf/messages.fr
+++ b/conf/messages.fr
@@ -39,7 +39,7 @@ landing.index.jumbotron.learn_more=En savoir plus
 landing.index.registration_form.placeholder.username=Choisissez un nom d'utilisateur
 landing.index.registration_form.placeholder.email=Courriel
 landing.index.registration_form.placeholder.password=Créez un mot de passe
-landing.index.registration_form.placeholder.register=S''inscrire sur Recogito
+landing.index.registration_form.placeholder.register=Inscrivez-vous sur Recogito
 landing.index.registration_form.disclaimer.text=Veuillez accepter nos <a href="{0}">conditions \
   d''utilisation</a> et l''enregistrement de votre courriel.
 


### PR DESCRIPTION
I suggest this change for the button's text to stick to the 2nd person that is in use in the register form