### PR TITLE
admin: allow to upload Gzip-ed gazetteers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,9 @@ libraryDependencies ++= Seq(
 
   "org.webjars" %% "webjars-play" % "2.6.2",
 
+  // To handle Zip files
+  "com.github.pathikrit" %% "better-files" % "3.6.0",
+
   // Scalagios core + transient dependencies
   "org.pelagios" % "scalagios-core" % "2.0.1" from "https://github.com/pelagios/scalagios/releases/download/v2.0.1/scalagios-core.jar",
   "org.openrdf.sesame" % "sesame-rio-n3" % "2.7.5",


### PR DESCRIPTION
If the uploaded file ends with '.gz' unzip it,
and import the gazetteer. This could be useful for large gazetteers such
as Pleiades.

Signed-off-by: Dimid Duchovny <dimidd@gmail.com>

<a href="https://imgflip.com/i/2ha89o"><img src="https://i.imgflip.com/2ha89o.jpg" title="made at imgflip.com"/></a>