### PR TITLE
Add configuration option for Elasticsearch cluster name

### DIFF
--- a/app/storage/es/ES.scala
+++ b/app/storage/es/ES.scala
@@ -57,7 +57,8 @@ class ES @Inject() (config: Configuration, lifecycle: ApplicationLifecycle) {
   lazy val client = {
     val host = config.getOptional[String]("es.host").getOrElse("localhost")
     val port = config.getOptional[Int]("es.port").getOrElse(9300)
-    val remoteClient = TcpClient.transport(ElasticsearchClientUri(host, port))
+    val clusterName = config.getOptional[String]("es.cluster.name").getOrElse("elasticsearch")
+    val remoteClient = TcpClient.transport(Settings.builder().put("cluster.name", clusterName).build(),ElasticsearchClientUri(host, port))
 
     Try(Await.result(remoteClient execute { clusterStats }, 3.seconds)) match {
       case Success(_) =>

--- a/conf/application.conf.template
+++ b/conf/application.conf.template
@@ -66,6 +66,7 @@ db.default.password="postgres-password-goes-here"
 # ~~~~~
 # es.host = localhost
 # es.port = 9300
+# es.cluster.name = elasticsearch
 
 # Evolutions
 # ~~~~~


### PR DESCRIPTION
In order to run the Elasticsearch implementation safely on some populated network, cluster names are nice. This configuration option lets Recogito follow along.

In particular, if you run the official Elasticsearch Docker images, they seem to belong to the "docker-cluster" cluster, rather than the default "elasticsearch" one, meaning Recogito can't connect.