### PR TITLE
Check for plugin directory before listing it

### DIFF
--- a/app/plugins/PluginRegistry.scala
+++ b/app/plugins/PluginRegistry.scala
@@ -28,6 +28,7 @@ object PluginRegistry {
   
   /** Recursively walks a directory, looking for files with the given name **/
   private def findFilesRecursive(name: String, dir: File): Seq[File] = {
+    if (dir.exists) {
     val all = dir.listFiles
    
     val dirs = all.filter(_.isDirectory)
@@ -36,6 +37,7 @@ object PluginRegistry {
     val matchingFiles = files.filter(_.getName == name)
     
     matchingFiles ++ dirs.flatMap(dir => findFilesRecursive(name, dir))
+    } else Seq()
   }
           
   def listConfigs(extensionPoint: String): Seq[Config] =

--- a/app/plugins/PluginRegistry.scala
+++ b/app/plugins/PluginRegistry.scala
@@ -29,14 +29,14 @@ object PluginRegistry {
   /** Recursively walks a directory, looking for files with the given name **/
   private def findFilesRecursive(name: String, dir: File): Seq[File] = {
     if (dir.exists) {
-    val all = dir.listFiles
-   
-    val dirs = all.filter(_.isDirectory)
-    val files = all.filter(_.isFile)
-    
-    val matchingFiles = files.filter(_.getName == name)
-    
-    matchingFiles ++ dirs.flatMap(dir => findFilesRecursive(name, dir))
+      val all = dir.listFiles
+
+      val dirs = all.filter(_.isDirectory)
+      val files = all.filter(_.isFile)
+
+      val matchingFiles = files.filter(_.getName == name)
+
+      matchingFiles ++ dirs.flatMap(dir => findFilesRecursive(name, dir))
     } else Seq()
   }
           


### PR DESCRIPTION
This fixes a server crash on clicking the "Annotation statistics" view if the plugin directory does not exist.